### PR TITLE
4 make container for warp layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
+import Container from "@/components/layout/container"
+
 export default function Home() {
   return (
-    <>
-      <div className="">Home</div>
-    </>
+    <Container>
+      <div>Home</div>
+    </Container>
   )
 }

--- a/src/components/layout/container.tsx
+++ b/src/components/layout/container.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils"
+
+interface ContainerProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export default function Container(props: ContainerProps) {
+  return (
+    <div className="p-[10px]">
+      <div
+        className={cn("mx-auto flex w-full max-w-[1420px]", props.className)}
+      >
+        {props.children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -14,75 +14,71 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <>
-      <motion.header
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="p-[10px]"
-      >
-        <div className="mx-auto max-w-[1420px]">
-          <div className="border-bone flex items-center justify-between gap-[2px] rounded-full border p-[3px]">
-            <div className="flex w-full gap-1">
-              <Link
-                href={siteConfig.href}
-                className={`${linkStyles} bg-birch !border-birch w-full text-center lg:max-w-sm`}
-              >
-                {siteConfig.name}
-              </Link>
-              <div className="hidden w-full gap-[2px] lg:flex">
-                {Object.entries(navConfig.header).map(
-                  ([key, { title, href }]) => (
-                    <Link key={key} href={href || ""} className={linkStyles}>
-                      {title}
-                    </Link>
-                  )
-                )}
-              </div>
-            </div>
-            <Link href="/contact" className={`${linkStyles} hidden md:block`}>
-              Contact&nbsp;now
+    <motion.header
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="p-[10px]"
+    >
+      <div className="mx-auto max-w-[1420px]">
+        <div className="border-bone flex items-center justify-between gap-[2px] rounded-full border p-[3px]">
+          <div className="flex w-full gap-1">
+            <Link
+              href={siteConfig.href}
+              className={`${linkStyles} bg-birch !border-birch w-full text-center lg:max-w-sm`}
+            >
+              {siteConfig.name}
             </Link>
-            <div
-              onClick={() => setIsOpen(!isOpen)}
-              className={`${linkStyles} md:hidden ${isOpen ? "bg-bone text-heavyMetal" : ""}`}
-              aria-label="Toggle menu"
-              aria-expanded={isOpen}
-            >
-              {isOpen ? <p>Close</p> : <p>Menu</p>}
-            </div>
-          </div>
-        </div>
-        <AnimatePresence>
-          {isOpen && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              className="border-bone mt-2 overflow-hidden rounded-3xl border md:hidden"
-            >
+            <div className="hidden w-full gap-[2px] lg:flex">
               {Object.entries(navConfig.header).map(
                 ([key, { title, href }]) => (
-                  <Link
-                    key={key}
-                    href={href || ""}
-                    className="text-bone hover:bg-bone hover:text-heavyMetal block p-4 font-medium transition-colors"
-                    onClick={() => setIsOpen(false)}
-                  >
+                  <Link key={key} href={href || ""} className={linkStyles}>
                     {title}
                   </Link>
                 )
               )}
+            </div>
+          </div>
+          <Link href="/contact" className={`${linkStyles} hidden md:block`}>
+            Contact&nbsp;now
+          </Link>
+          <div
+            onClick={() => setIsOpen(!isOpen)}
+            className={`${linkStyles} md:hidden ${isOpen ? "bg-bone text-heavyMetal" : ""}`}
+            aria-label="Toggle menu"
+            aria-expanded={isOpen}
+          >
+            {isOpen ? <p>Close</p> : <p>Menu</p>}
+          </div>
+        </div>
+      </div>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="border-bone mt-2 overflow-hidden rounded-3xl border md:hidden"
+          >
+            {Object.entries(navConfig.header).map(([key, { title, href }]) => (
               <Link
-                href="/contact"
+                key={key}
+                href={href || ""}
                 className="text-bone hover:bg-bone hover:text-heavyMetal block p-4 font-medium transition-colors"
                 onClick={() => setIsOpen(false)}
               >
-                Contact now
+                {title}
               </Link>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </motion.header>
-    </>
+            ))}
+            <Link
+              href="/contact"
+              className="text-bone hover:bg-bone hover:text-heavyMetal block p-4 font-medium transition-colors"
+              onClick={() => setIsOpen(false)}
+            >
+              Contact now
+            </Link>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.header>
   )
 }


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and dependencies of the project. The most important changes include adding environment variables, updating ESLint rules, configuring Husky hooks, adding Prettier configuration, and updating dependencies in `package.json` and `pnpm-lock.yaml`.

Environment and configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R11): Added environment variables for application configuration, NextAuth, and Google OAuth.
* [`.eslintrc.json`](diffhunk://#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL2-R27): Updated ESLint rules to include import order and no duplicates, and modified formatting rules.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R17): Configured VSCode settings for TypeScript, format on save, and default formatters for various file types.

Tooling and dependencies:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R37): Added new dependencies and devDependencies, including `@radix-ui/react-slot`, `class-variance-authority`, `clsx`, `framer-motion`, `lucide-react`, `next-themes`, `husky`, `prettier`, `prettier-plugin-tailwindcss`, `tailwind-merge`, and `tailwindcss-animate`. Updated the version to `0.1.3`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R43): Updated to include new dependencies and their respective versions and integrity hashes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R43) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR60-R71) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR320-R337) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR562-R571) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR868-R881) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR970-R974) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1193-R1197) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1234-R1239) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1410-R1469) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1665-R1672) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1988-R2000) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2274-R2281) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2733-R2739) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2837-R2838) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3042-R3045) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3077-R3081) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3244-R3249) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3496-R3501)

Additional configurations:

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1): Added a pre-commit hook to run lint fixes.
* [`.husky/pre-push`](diffhunk://#diff-43bbc75a027a43baaddc57670d8ab49b4aa2981053c3cabba17567723d3a9fb6R1): Added a pre-push hook to run the build command.
* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R1-R6): Added Prettier configuration with TailwindCSS plugin and formatting rules.
* [`components.json`](diffhunk://#diff-2c9eb56f775dd960fa3fb60253b2d30f21baae2e81f352e63a0984f129408016R1-R21): Added configuration for ShadCN UI components with TailwindCSS and alias settings.